### PR TITLE
Implement employees grid on dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class DashboardController extends Controller
+{
+    /**
+     * Display the dashboard with a list of employees fetched from the remote API.
+     */
+    public function index(Request $request)
+    {
+        $employees = [];
+
+        $token = $request->session()->get('remote_token');
+
+        if ($token) {
+            try {
+                $response = Http::withToken($token)
+                    ->get('https://corpve.mierp.com.mx/api/employees');
+
+                if ($response->successful()) {
+                    $employees = $response->json();
+                }
+            } catch (\Exception $e) {
+                // silently fail and keep employees empty
+            }
+        }
+
+        return view('dashboard', [
+            'employees' => $employees,
+        ]);
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,5 +1,18 @@
 <x-layouts.app :title="__('Dashboard')">
-    <div class="flex h-full w-full flex-1 flex-col gap-4 rounded-xl">
-        ok
+    <div class="flex flex-col gap-4">
+        <h1 class="text-xl font-bold">{{ __('Employees') }}</h1>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            @forelse ($employees as $employee)
+                <div class="border rounded p-4 flex flex-col items-center">
+                    <img class="h-20 w-20 rounded-full object-cover mb-2" src="{{ $employee['photo'] ?? '' }}" alt="{{ $employee['first_name'] ?? '' }} {{ $employee['last_name'] ?? '' }}" />
+                    <div class="text-center">
+                        <p class="font-semibold">{{ $employee['first_name'] ?? '' }} {{ $employee['last_name'] ?? '' }}</p>
+                        <p class="text-sm text-gray-500">{{ $employee['email'] ?? '' }}</p>
+                    </div>
+                </div>
+            @empty
+                <p class="text-gray-500">{{ __('No employees found.') }}</p>
+            @endforelse
+        </div>
     </div>
 </x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 use App\Http\Controllers\RemoteLoginController;
+use App\Http\Controllers\DashboardController;
 
 Route::get('/', function () {
     // return view('welcome');
@@ -10,7 +11,7 @@ Route::get('/', function () {
     return redirect()->route('dashboard');
 })->name('home');
 
-Route::view('dashboard', 'dashboard')
+Route::get('dashboard', [DashboardController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
 


### PR DESCRIPTION
## Summary
- add new `DashboardController` to retrieve employees from remote API
- route Dashboard through controller
- render employees in a grid with photo, name and email

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_b_68766e5c58ec832881ed49c084fe6826