### PR TITLE
Add default employee image and attendance button

### DIFF
--- a/public/images/default-user.svg
+++ b/public/images/default-user.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="20" r="12" fill="#cbd5e1" />
+  <path d="M16 52c0-8.8 7.2-16 16-16s16 7.2 16 16v4H16v-4z" fill="#cbd5e1" />
+</svg>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -4,11 +4,12 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
             @forelse ($employees as $employee)
                 <div class="border rounded p-4 flex flex-col items-center">
-                    <img class="h-20 w-20 rounded-full object-cover mb-2" src="{{ $employee['photo'] ?? '' }}" alt="{{ $employee['first_name'] ?? '' }} {{ $employee['last_name'] ?? '' }}" />
+                    <img class="w-24 h-24 rounded-full object-cover mb-2" src="{{ $employee['photo'] ?: asset('images/default-user.svg') }}" alt="{{ $employee['first_name'] ?? '' }} {{ $employee['last_name'] ?? '' }}" />
                     <div class="text-center">
                         <p class="font-semibold">{{ $employee['first_name'] ?? '' }} {{ $employee['last_name'] ?? '' }}</p>
                         <p class="text-sm text-gray-500">{{ $employee['email'] ?? '' }}</p>
                     </div>
+                    <button class="mt-4 px-4 py-2 bg-blue-600 text-white rounded shadow hover:bg-blue-700">{{ __('Registrar asistencia') }}</button>
                 </div>
             @empty
                 <p class="text-gray-500">{{ __('No employees found.') }}</p>


### PR DESCRIPTION
## Summary
- ensure each employee card uses a fixed size avatar
- add a fallback default image for employees without photos
- provide a button in each employee card to register attendance

## Testing
- `composer test` *(fails: vendor directory missing due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_6876739aff8083289655b805e2021c4c