### PR TITLE
Add QR scanning view

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -18,6 +18,9 @@
                 <flux:navlist.item icon="home" :href="route('dashboard')"
                     :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard') }}
                 </flux:navlist.item>
+                <flux:navlist.item icon="qr-code" :href="route('qr.scan')"
+                    :current="request()->routeIs('qr.scan')" wire:navigate>{{ __('Scan QR') }}
+                </flux:navlist.item>
             </flux:navlist.group>
         </flux:navlist>
 

--- a/resources/views/qr-scan.blade.php
+++ b/resources/views/qr-scan.blade.php
@@ -1,0 +1,26 @@
+<x-layouts.app :title="__('Scan QR')">
+    <div class="p-4 flex flex-col items-center gap-4">
+        <flux:heading>{{ __('Scan QR Code') }}</flux:heading>
+        <div id="qr-reader" class="w-64 h-64" wire:ignore></div>
+        <div id="qr-result" class="mt-4 font-semibold text-center"></div>
+    </div>
+
+    <script src="https://unpkg.com/html5-qrcode@2.3.10/html5-qrcode.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const resultElem = document.getElementById('qr-result');
+            const html5QrCode = new Html5Qrcode('qr-reader');
+            Html5Qrcode.getCameras().then(cameras => {
+                if (cameras && cameras.length) {
+                    html5QrCode.start({ facingMode: 'environment' }, { fps: 10, qrbox: { width: 200, height: 200 } }, decodedText => {
+                        resultElem.textContent = decodedText;
+                    });
+                } else {
+                    resultElem.textContent = 'No camera found.';
+                }
+            }).catch(err => {
+                resultElem.textContent = 'Error: ' + err;
+            });
+        });
+    </script>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ Route::post('remote-login', [RemoteLoginController::class, 'login'])->name('remo
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');
 
+    Route::view('qr-scan', 'qr-scan')->name('qr.scan');
+
     Volt::route('settings/profile', 'settings.profile')->name('settings.profile');
     Volt::route('settings/password', 'settings.password')->name('settings.password');
     Volt::route('settings/appearance', 'settings.appearance')->name('settings.appearance');


### PR DESCRIPTION
## Summary
- add a new page `qr-scan.blade.php` that uses html5-qrcode to read a QR code and display the decoded value
- expose route `/qr-scan` under auth middleware and link it from the sidebar

## Testing
- `composer test` *(fails: missing vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687eca9b64dc8328a26bd79c2be2de21